### PR TITLE
Allow TP to get serialized txn header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 # Exclude IDE and Editor files
 /.idea/
 *.sublime*
+.vscode/
 
 build/
 

--- a/include/sawtooth/transaction_processor.h
+++ b/include/sawtooth/transaction_processor.h
@@ -31,7 +31,8 @@ namespace sawtooth {
 // Note: SdkProtocolVersion is the highest version the SDK supports
 enum class FeatureVersion: uint32_t {
     FeatureUnused = 0,
-    SdkProtocolVersion = 0,
+    FeatureCustomHeaderStyle = 1,
+    SdkProtocolVersion = 1,
 };
 
 static const unsigned int FeatureVersionToUnsignedInt(
@@ -41,9 +42,12 @@ static const unsigned int FeatureVersionToUnsignedInt(
         case FeatureVersion::FeatureUnused:
             value = 0;
             break;
+        case FeatureVersion::FeatureCustomHeaderStyle:
+            value = 1;
+            break;
         // case FeatureVersion::SdkProtocolVersion:
         default:
-            value = 0;
+            value = 1;
     }
     return value;
 }
@@ -59,6 +63,9 @@ class TransactionProcessorImpl: public TransactionProcessor {
     // Processor.  All the TransactionHandler objects must be registered
     // before run is called.
     void RegisterHandler(TransactionHandlerUPtr handler);
+
+    // Sets the TpProcessRequest header style, default set to EXPANDED
+    void SetHeaderStyle(TpRequestHeaderStyle style);
 
     // The main entry point for the TransactionProcessor. It will not return
     // until the TransactionProcessor shuts down.
@@ -78,6 +85,7 @@ class TransactionProcessorImpl: public TransactionProcessor {
 
     std::map<std::string, TransactionHandlerPtr> handlers;
     FeatureVersion highest_sdk_feature_requested;
+    TpRegisterRequest_TpProcessRequestHeaderStyle header_style;
 };
 
 }  // namespace sawtooth

--- a/include/sawtooth/transaction_processor.h
+++ b/include/sawtooth/transaction_processor.h
@@ -24,6 +24,30 @@
 
 namespace sawtooth {
 
+// This is the version used by SDK to match if validator supports feature
+// it requested during registration. It should only be incremented when
+// there are changes in TpRegisterRequest. Remember to sync this
+// information in validator if changed.
+// Note: SdkProtocolVersion is the highest version the SDK supports
+enum class FeatureVersion: uint32_t {
+    FeatureUnused = 0,
+    SdkProtocolVersion = 0,
+};
+
+static const unsigned int FeatureVersionToUnsignedInt(
+        const FeatureVersion& feature_version) {
+    unsigned int value;
+    switch (feature_version) {
+        case FeatureVersion::FeatureUnused:
+            value = 0;
+            break;
+        // case FeatureVersion::SdkProtocolVersion:
+        default:
+            value = 0;
+    }
+    return value;
+}
+
 // The main processing class for the Sawtooth SDK.
 class TransactionProcessorImpl: public TransactionProcessor {
  public:
@@ -53,6 +77,7 @@ class TransactionProcessorImpl: public TransactionProcessor {
     MessageStreamPtr response_stream;
 
     std::map<std::string, TransactionHandlerPtr> handlers;
+    FeatureVersion highest_sdk_feature_requested;
 };
 
 }  // namespace sawtooth

--- a/include/sawtooth_sdk.h
+++ b/include/sawtooth_sdk.h
@@ -54,8 +54,12 @@ typedef std::shared_ptr<TransactionHeader> TransactionHeaderPtr;
 // The transaction data for a Transaction Processing request.
 class Transaction final {
  public:
-    Transaction(TransactionHeaderPtr header, StringPtr payload, StringPtr signature):
-            header_(header), payload_(payload), signature_(signature) {
+    Transaction(
+            TransactionHeaderPtr header,
+            StringPtr payload,
+            StringPtr signature,
+            StringPtr header_bytes
+    ): header_(header), payload_(payload), signature_(signature), header_bytes_(header_bytes) {
     }
 
     Transaction (const Transaction&) = delete;
@@ -74,10 +78,15 @@ class Transaction final {
         return *(this->signature_);
     }
 
+    const std::string& header_bytes() const {
+        return *(this->header_bytes_);
+    }
+
  private:
     TransactionHeaderPtr header_;
     StringPtr payload_;
     StringPtr signature_;
+    StringPtr header_bytes_;
 };
 typedef std::unique_ptr<Transaction> TransactionUPtr;
 
@@ -184,6 +193,12 @@ typedef std::unique_ptr<TransactionHandler> TransactionHandlerUPtr;
 typedef std::shared_ptr<TransactionHandler> TransactionHandlerPtr;
 
 
+// Used to set the transaction request header style
+enum TpRequestHeaderStyle {
+    HeaderStyleUnset = 1,
+    HeaderStyleExpanded,
+    HeaderStyleRaw
+};
 
 class TransactionProcessor {
 public:
@@ -193,6 +208,9 @@ public:
     // Processor.  All the TransactionHandler objects must be registered
     // before run is called.
     virtual void RegisterHandler(TransactionHandlerUPtr handler) = 0;
+
+    // Sets the TpProcessRequest header style, default set to EXPANDED
+    virtual void SetHeaderStyle(TpRequestHeaderStyle style) = 0;
 
     // The main entry point for the TransactionProcessor. It will not return
     // until the TransactionProcessor shuts down.

--- a/protos/processor.proto
+++ b/protos/processor.proto
@@ -22,7 +22,10 @@ import "transaction.proto";
 
 
 // The registration request from the transaction processor to the
-// validator/executor
+// validator/executor.
+//
+// The protocol_version field is used to check if the validator supports
+// requested features by a transaction processor.
 message TpRegisterRequest {
 
     // A settled upon name for the capabilities of the transaction processor.
@@ -42,6 +45,11 @@ message TpRegisterRequest {
     // The maximum number of transactions that this transaction processor can
     // handle at once.
     uint32 max_occupancy = 5;
+
+    // Validator can make use of this field to check if the requested features
+    // are supported. Registration requests can be either accepted or rejected
+    // based on this field.
+    uint32 protocol_version = 6;
 }
 
 // A response sent from the validator to the transaction processor
@@ -54,6 +62,10 @@ message TpRegisterResponse {
     }
 
     Status status = 1;
+
+    // Respond back with protocol_version, the value that can be used by SDK to
+    // know if validator supports expected feature.
+    uint32 protocol_version = 2;
 }
 
 // The unregistration request from the transaction processor to the

--- a/protos/processor.proto
+++ b/protos/processor.proto
@@ -26,7 +26,20 @@ import "transaction.proto";
 //
 // The protocol_version field is used to check if the validator supports
 // requested features by a transaction processor.
+// Following are the versions supported:
+//     1    Transaction processor can request for either raw header bytes or
+//          deserialized TransactionHeader field in the TpProcessRequest
+//          message. The default option is set to send deserialized
+//          TransactionHeader.
 message TpRegisterRequest {
+    // enum used to fill in transaction header field in TpProcessRequest.
+    // This field can be set before transaction processor registers with
+    // validator.
+    enum TpProcessRequestHeaderStyle {
+        HEADER_STYLE_UNSET = 0;
+        EXPANDED = 1;
+        RAW = 2;
+    }
 
     // A settled upon name for the capabilities of the transaction processor.
     // For example: intkey, xo
@@ -50,6 +63,10 @@ message TpRegisterRequest {
     // are supported. Registration requests can be either accepted or rejected
     // based on this field.
     uint32 protocol_version = 6;
+
+    // Setting it to RAW, validator would fill in serialized transaction header
+    // when sending TpProcessRequest to the transaction processor.
+    TpProcessRequestHeaderStyle request_header_style = 7;
 }
 
 // A response sent from the validator to the transaction processor
@@ -91,10 +108,21 @@ message TpUnregisterResponse {
 // The request from the validator/executor of the transaction processor
 // to verify a transaction.
 message TpProcessRequest {
-    TransactionHeader header = 1;  // The transaction header
-    bytes payload = 2;  // The transaction payload
-    string signature = 3;  // The transaction header_signature
-    string context_id = 4; // The context_id for state requests.
+    // The de-serialized transaction header from client request
+    TransactionHeader header = 1;
+
+    // The transaction payload
+    bytes payload = 2;
+
+    // The transaction header_signature
+    string signature = 3;
+
+    // The context_id for state requests.
+    string context_id = 4;
+
+    // The serialized header as received by client.
+    // Controlled by a flag during transaction processor registration.
+    bytes header_bytes = 5;
 }
 
 


### PR DESCRIPTION
RFC text/0000-raw-txn-header.md describes in brief the need to
have serialized transaction header sent to transaction processor.
1. Introduce required proto changes, set EXPANDED as default.
2. Introduces a new method for setting transaction header style.

Please refer to hyperledger/sawtooth-rfcs#23 for detailed
description.

Minor: Add .project (IDE created folder) to gitignore