### PR TITLE
Set message type for invalid transaction

### DIFF
--- a/src/transaction_processor.cpp
+++ b/src/transaction_processor.cpp
@@ -160,6 +160,7 @@ void TransactionProcessorImpl::HandleProcessingRequest(const void* msg,
                                 << e.what());
                     response.set_status(
                         TpProcessResponse::INVALID_TRANSACTION);
+		    response.set_message(e.what());
                 } catch(...) {
                     LOG4CXX_ERROR(logger, "applicator->Apply unknown error");
                     response.set_status(


### PR DESCRIPTION
To communicate the rejection reason thrown by the TP,
the 'message' attribute of Invalid Transaction Exception
is populated along with the 'transaction_id'

Signed-off-by: raghav.aneja <raghav.aneja@intel.com>