### PR TITLE
Added support for Event Handling

### DIFF
--- a/include/sawtooth/global_state.h
+++ b/include/sawtooth/global_state.h
@@ -65,6 +65,10 @@ class GlobalStateImpl: public GlobalState {
     // Delete multiple entries from global state.
     void DeleteState(const std::vector<std::string>& address) const;
 
+    // Add Events for every transaction
+    void AddEvent(const std::string& event_type ,
+       const std::vector<KeyValue>& kv_pairs, const std::string& event_data) const;
+
  private:
     std::string context_id;
     MessageStreamPtr message_stream;

--- a/include/sawtooth_sdk.h
+++ b/include/sawtooth_sdk.h
@@ -119,6 +119,11 @@ class GlobalState {
 
     // Delete multiple entries from global state.
     virtual void DeleteState(const std::vector<std::string>& address) const = 0;
+
+    // Add a new event to the execution result for this transaction.
+    virtual void AddEvent(const std::string& event_type,
+       const std::vector<KeyValue>& kv_pairs, const std::string& event_data) const = 0;
+
 };
 typedef std::shared_ptr<GlobalState> GlobalStatePtr;
 typedef std::unique_ptr<GlobalState> GlobalStateUPtr;


### PR DESCRIPTION
TP can invoke addEvent method to create a custom
event based on business requirement. The arguments
to be passed should include 'event_type', 'attributes',
'event_data'

Signed-off-by: raghav.aneja <raghav.aneja@intel.com>