### PR TITLE
Add TpAddReceiptData capability

### DIFF
--- a/include/sawtooth/global_state.h
+++ b/include/sawtooth/global_state.h
@@ -69,6 +69,9 @@ class GlobalStateImpl: public GlobalState {
     void AddEvent(const std::string& event_type ,
        const std::vector<KeyValue>& kv_pairs, const std::string& event_data) const;
 
+    // Add receipt data to the execution result of this transaction
+    void AddReceiptData(const std::string& data) const;
+
  private:
     std::string context_id;
     MessageStreamPtr message_stream;

--- a/include/sawtooth_sdk.h
+++ b/include/sawtooth_sdk.h
@@ -124,6 +124,8 @@ class GlobalState {
     virtual void AddEvent(const std::string& event_type,
        const std::vector<KeyValue>& kv_pairs, const std::string& event_data) const = 0;
 
+    // Add receipt data to the execution result of this transaction
+    virtual void AddReceiptData(const std::string& data) const = 0;
 };
 typedef std::shared_ptr<GlobalState> GlobalStatePtr;
 typedef std::unique_ptr<GlobalState> GlobalStateUPtr;

--- a/src/global_state.cpp
+++ b/src/global_state.cpp
@@ -159,5 +159,27 @@ void GlobalStateImpl::AddEvent(const std::string& event_type ,
 }
 
 
+void GlobalStateImpl::AddReceiptData(const std::string& data) const {
+    TpReceiptAddDataRequest request;
+    TpReceiptAddDataResponse response;
+
+    request.set_context_id(this->context_id);
+    request.set_data(data);
+
+    FutureMessagePtr future = this->message_stream->SendMessage(
+        Message::TP_RECEIPT_ADD_DATA_REQUEST, request);
+    future->GetMessage(Message::TP_RECEIPT_ADD_DATA_RESPONSE, &response);
+
+    if (response.status() == TpReceiptAddDataResponse::ERROR){
+      std::stringstream error;
+      error << "Failed to add receipt data " << data;
+      throw std::runtime_error(error.str());
+    } else if (response.status() == TpReceiptAddDataResponse::STATUS_UNSET){
+      std::stringstream error;
+      error << "Status was not set for TpReceiptAddDataResponse";
+      throw std::runtime_error(error.str());
+    }
+}
+
 }  // namespace sawtooth
 


### PR DESCRIPTION
This adds the TpAddReceiptData methods to global_state.cpp.  
Signed-off-by: Kevin O'Donnell <kevin@blockchaintp.com>